### PR TITLE
Wrapper API suggestion

### DIFF
--- a/src/quiescent.clj
+++ b/src/quiescent.clj
@@ -16,3 +16,28 @@
     `(def ~name ~docstr (quiescent/component (fn ~argvec ~@body)))))
 
 
+(defmacro wrapper
+  [child & body]
+  `(-> (quiescent/make-wrapper ~child)
+       ~@body
+       quiescent/wrapper-compile))
+
+(defmacro on-update
+  [v bindings & body]
+  `(quiescent/on-update* ~v (fn ~bindings ~@body)))
+
+(defmacro on-mount
+  [v bindings & body]
+  `(quiescent/on-mount* ~v (fn ~bindings ~@body)))
+
+(defmacro on-will-mount
+  [v bindings & body]
+  `(quiescent/on-will-mount* ~v (fn ~bindings ~@body)))
+
+(defmacro on-will-update
+  [v bindings & body]
+  `(quiescent/on-will-update* ~v (fn ~bindings ~@body)))
+
+(defmacro on-will-unmount
+  [v bindings & body]
+  `(quiescent/on-will-unmount* ~v (fn ~bindings ~@body)))

--- a/src/quiescent.cljs
+++ b/src/quiescent.cljs
@@ -69,74 +69,59 @@
                 (binding [*component* this]
                   (f)))))}))
 
+(defn make-wrapper
+  [child]
+  {:child child
+   :callbacks {}})
 
+(defn wrapper-clb
+  [wrapper type clb]
+  (assoc-in wrapper [:callbacks type] clb))
 
-(defn on-update
+(defn wrapper-compile
+  [{:keys [child callbacks]}]
+  (WrapperComponent. (clj->js (assoc callbacks :wrappee child))))
+
+(defn on-update*
   "Wrap a component, specifying a function to be called on the
   componentDidUpdate lifecycle event.
 
   The function will be passed the rendered DOM node."
-  [child f]
-  (WrapperComponent #js {:wrappee child
-                         :onUpdate f}))
+  [v f]
+  (wrapper-clb v :onUpdate f))
 
-(defn on-mount
+(defn on-mount*
   "Wrap a component, specifying a function to be called on the
   componentDidMount lifecycle event.
 
   The function will be passed the rendered DOM node."
-  [child f]
-  (WrapperComponent #js {:wrappee child
-                         :onMount f}))
-
-(defn on-render
-  "Wrap a component, specifying a function to be called on the
-  componentDidMount AND the componentDidUpdate lifecycle events.
-
-  The function will be passed the rendered DOM node."
-  [child f]
-  (WrapperComponent #js {:wrappee child
-                         :onMount f
-                         :onUpdate f}))
+  [v f]
+  (wrapper-clb v :onMount f))
 
 
-(defn on-will-mount
+(defn on-will-mount*
   "Wrap a component, specifying a function to be called on the
   componentWillMount lifecycle event.
 
   The function will be called with no arguments."
-  [child f]
-  (WrapperComponent #js {:wrappee child
-                         :onWillMount f}))
+  [v f]
+  (wrapper-clb v :onWillMount f))
 
-(defn on-will-update
+(defn on-will-update*
   "Wrap a component, specifying a function to be called on the
   componentWillUpdate lifecycle event.
 
   The function will be called with no arguments."
-  [child f]
-  (WrapperComponent #js {:wrappee child
-                         :onWillUpdate f}))
+  [v f]
+  (wrapper-clb v :onWillUpdate f))
 
-(defn on-will-render
-  "Wrap a component, specifying a function to be called on the
-  componentWillMount AND the componentWillUpdate lifecycle events.
-
-  The function will be called with no arguments."
-  [child f]
-  (WrapperComponent #js {:wrappee child
-                         :onWillMount f
-                         :onWillUpdate f}))
-
-
-(defn on-will-unmount
+(defn on-will-unmount*
   "Wrap a component, specifying a function to be called on the
   componentWillUnmount lifecycle event.
 
   The function will be called with no arguments."
-  [child f]
-  (WrapperComponent #js {:wrappee child
-                         :onWillUnmount f}))
+  [v f]
+  (wrapper-clb v :onWillUnmounte f))
 
 
 (defn render


### PR DESCRIPTION
Hello!

I suggest more flexible wrapper API, so we can define any number of callbacks and maybe other options in a future.

``` clojure
(defcomponent Input
  [input-state]
  (wrapper
   (d/input {:id "my-input"
             :value (:value input-state)})
   (on-mount [node]
             (do-on-mount))
   (on-update [node]
              (do-on-update))))
```
