### PR TITLE
Store references to generated dom functions inside a hashmap as well

### DIFF
--- a/src/quiescent/dom.clj
+++ b/src/quiescent/dom.clj
@@ -19,6 +19,9 @@
   arguments. The properties argument may be a Clojure map or a JS
   object."
   [& tags]
-  (apply list 'do (clojure.core/map tag-definition tags)))
+  `(do (do ~@(clojure.core/map tag-definition tags))
+       (def ~'defined-tags
+         ~(zipmap (map (comp keyword name) tags)
+                 tags))))
 
 


### PR DESCRIPTION
On two projects I'm working on that use quiescent, I prefer to work with a data driven ui structure (nested hash maps, or even hiccup). In these projects I actually store the UI structure in an atom and then simply call `render` on this structure whenever I want to update using react. This is quite hard to accomplish without first class namespaces. I'd like to see a change like this one that defines a hash-map called `defined-tags` this way I can more easily drive my render routines with data rather than canned functions. 

Example:

``` clojure
(render {:type :div
              :contents [{:type :h2 :contents "Hello World"}]})
```

The function `render` can now be easily be built using the `defined-tags` hash-map, apply, and about 20 lines of code. 
