### PR TITLE
Add custom component properties

### DIFF
--- a/src/quiescent.clj
+++ b/src/quiescent.clj
@@ -2,17 +2,20 @@
 
 (defmacro defcomponent
   "Creates a ReactJS component with the given name, an (optional)
-  docstring, an argument vector and a body which will be used as the
-  rendering function to quiescent/component.
+  docstring, an argument vector, (optional) custom component properties
+  and a body which will be used as the rendering function to quiescent/component.
 
   Shorthand for:
 
-  (def name (quiescent/component (fn [value] body)))"
+  (def name (quiescent/component (fn [value] body) props))"
   [name & forms]
   (let [has-docstr? (string? (first forms))
+        has-props? (map? (if has-docstr? (nth forms 2) (second forms)))
         docstr (if has-docstr? (first forms) "")
         argvec (if has-docstr? (second forms) (first forms))
-        body (if has-docstr? (drop 2 forms) (drop 1 forms))]
-    `(def ~name ~docstr (quiescent/component (fn ~argvec ~@body)))))
-
-
+        props (if has-props? (if has-docstr? (nth forms 2) (second forms)) {})
+        body (cond
+               (and has-docstr? has-props?) (drop 3 forms)
+               (or has-docstr? has-props?) (drop 2 forms)
+               :else (drop 1 forms))]
+    `(def ~name ~docstr (quiescent/component (fn ~argvec ~@body) ~props))))


### PR DESCRIPTION
This adds a way to specify custom component properties when creating a
React class, like, for example, 'key'. It is may be useful when e.g. you
work with ReactCSSTransitionGroup.

This commit extends defcomponent and component so now they accept
optional map, which will then be used for React.createClass. New syntax
is:

```clj
(defcomponent Bar "desc" [data] {:key "foo"}
  (dom/div ...))
```

and

```clj
(component (fn [data] (dom/div ...)) {:key "foo"})
```