### PR TITLE
Adding proper unmounting capabilities.

### DIFF
--- a/src/quiescent.cljs
+++ b/src/quiescent.cljs
@@ -79,7 +79,7 @@
             (this-as this
               (when-let [f (aget (.-props this) "onWillUnmount")]
                 (binding [*component* this]
-                  (f)))))}))
+                  (f (.getDOMNode this))))))}))
 
 (defn wrapper
   "Create a wrapper function for a compoment implementing multiple
@@ -164,3 +164,9 @@
   specified DOM node."
   [component node]
   (.renderComponent js/React component node))
+
+(defn unmount-at-node
+  "Remove a mounted ReactJS component from the DOM and clean up its
+  event handlers and state."
+  [node]
+  (.unmountComponentAtNode js/React node))


### PR DESCRIPTION
This little fix enables us to write this kind of wrapper:

```clojure
(q/defcomponent SelfUpdatingWrapper
  []
  (letfn [(render [node] (q/render (Main @world) node))]
    (q/wrapper
     (html [:div])
     :onMount (fn [node]
                (let [renderer (partial render node)]
                  (renderer)
                  (add-watch world "renderer-id" renderer)))
     :onWillUnmount (fn [node]
                      (remove-watch world "renderer-id")
                      (q/unmount-at-node node)))))
```

Exposing this component like

```clojure
(def ^:export component SelfUpdatingWrapper)
```

gives the ability to use it as a regular component in another ReactJS project:

```javascript
ClojureScriptComponent = React.createClass({
  render: function() {
    return clojurescriptproject.namespace.component();
  }
});
```

Now I can freely mount/unmount `ClojureScriptComponent` within any ReactJS project while it is sandboxed in its own "world". That's what we're doing currently in our project in production.