### PR TITLE
Remove deprecation notice from q/render

### DIFF
--- a/src/quiescent/core.cljs
+++ b/src/quiescent/core.cljs
@@ -319,10 +319,7 @@
   (wrapper child :onWillUnmount f))
 
 (defn render
-  "DEPRECATED. Wrappers do not work properly. Prefer adding lifecycle
-   methods at component creation time.
-
-   Given an Element, immediately render it, rooted to the
+  "Given an Element, immediately render it, rooted to the
    specified DOM node."
   [element node]
   (.render js/React element node))


### PR DESCRIPTION
It looked like this deprecation notice was added in error, since the render function seems pretty important and doesn't have to do with wrappers. Here's a patch if you like!