### PR TITLE
extend dom.clj to allow for defining tags for composite components (reac...

### DIFF
--- a/src/quiescent/dom.clj
+++ b/src/quiescent/dom.clj
@@ -1,16 +1,29 @@
 (ns quiescent.dom)
 
+(defn- component-fn-symbol [js-namespace tag]
+  (symbol (str "js/" js-namespace "." (name tag))))
+
+(defn- tag-definition-base [f tag]
+  `(defn ~tag [& args#]
+     ~(str "Return a component for " tag)
+     (let [a# (make-array 0)]
+       (.push a# (cljs.core/clj->js (first args#)))
+       (doseq [arg# (rest args#)] (.push a# arg#))
+       (.apply ~f nil a#))))
+
 (defn tag-definition
   "Return a form to defining a wrapper function for a ReactJS tag
   component."
-  [tag]
-  (let [f (symbol (str "js/React.DOM." (name tag)))]
-    `(defn ~tag [& args#]
-       ~(str "Return a component for ")
-       (let [a# (make-array 0)]
-         (.push a# (cljs.core/clj->js (first args#)))
-         (doseq [arg# (rest args#)] (.push a# arg#))
-         (.apply ~f nil a#)))))
+  ([tag]
+   (tag-definition-base (component-fn-symbol "React" tag) tag))
+  ([js-namespace tag]
+   (tag-definition-base `(.createFactory js/React ~(component-fn-symbol js-namespace tag)) tag)))
+
+(defn- define-tags-base [mapping-fn tags]
+  `(do (do ~@(clojure.core/map mapping-fn tags))
+     (def ~'defined-tags
+       ~(zipmap (map (comp keyword name) tags)
+                tags))))
 
 (defmacro define-tags
   "Macro which expands to a do block which contains a defmacro for
@@ -19,9 +32,7 @@
   arguments. The properties argument may be a Clojure map or a JS
   object."
   [& tags]
-  `(do (do ~@(clojure.core/map tag-definition tags))
-       (def ~'defined-tags
-         ~(zipmap (map (comp keyword name) tags)
-                 tags))))
+  (define-tags-base tag-definition tags))
 
-
+(defmacro define-composite-tags [js-namespace & tags]
+  (define-tags-base #(tag-definition js-namespace %) tags))


### PR DESCRIPTION
...t extensions), because a significant amount of code can be shared.

for example react-bootstrap:
```clojure
(ns example.quiescent.react-bootstrap
  (:require-macros [quiescent.dom :refer [define-composite-tags]])
  (:require [cljsjs.react-bootstrap]))

(define-composite-tags "ReactBootstrap"
  Accordion Affix AffixMixin Alert BootstrapMixin Badge Button ButtonGroup ButtonToolbar
  Carousel CarouselItem Col CollapsableMixin DropdownButton DropdownMenu
  DropdownStateMixin FadeMixin Glyphicon Grid Input Interpolate Jumbotron Label
  ListGroup ListGroupItem MenuItemModal Nav Navbar NavItem ModalTrigger OverlayTrigger
  OverlayMixin PageHeader Panel PanelGroup PageItem Pager Popover ProgressBar Row
  SplitButton SubNav TabbedArea Table TabPane Tooltip Well)
```
use it then like (of course the bootstrap css needs to be included in the html):
```clojure
(ns example.webapp
  (:require [quiescent.core :refer [defcomponent]]
            [example.quiescent.react-bootstrap :refer [Button]]))

(defcomponent ExampleButton
  [label onClick]
  (Button {:onClick onClick} label))
```