### PR TITLE
Use symbol name for defcomponent as default name

### DIFF
--- a/src/quiescent/core.clj
+++ b/src/quiescent/core.clj
@@ -46,5 +46,6 @@
   [name & forms]
   (let [[docstr forms] (extract-docstr forms)
         [options forms] (extract-opts forms)
-        [argvec & body] forms]
+        [argvec & body] forms
+        options (merge {:name (str name)} options)]
     `(def ~name ~docstr (quiescent.core/component (fn ~argvec ~@body) ~options))))


### PR DESCRIPTION
When using `defcomponent` this will assign the component name to the `:name` metadata if not provided. This makes it a tad less clumsy when using tools like the React chrome extension without having to specify what is usually the same literal name as the symbol. 