### PR TITLE
Ignoring mask from cljs.core.

### DIFF
--- a/src/quiescent/dom.cljs
+++ b/src/quiescent/dom.cljs
@@ -1,5 +1,5 @@
 (ns quiescent.dom
-  (:refer-clojure :exclude [time map meta])
+  (:refer-clojure :exclude [time map meta mask])
   (:require-macros [quiescent.dom :as dm])
   (:require [quiescent.factory]
             [cljsjs.react]))


### PR DESCRIPTION
To avoid the:
`WARNING: mask already refers to: cljs.core/mask being replaced by: quiescent.dom/mask at line 7 resources/public/js/compiled/out/quiescent/dom.cljs`